### PR TITLE
Fix path handling for training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,8 @@ python -m venv .env
 .env\Scripts\activate
 pip install -r requirements.txt
 pytest
-python scripts/train.py
+python -m scripts.train
 ```
+
+Run the training script as a module (with `-m`) so that package imports
+resolve correctly.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,7 +4,6 @@ Train PPO on the custom Tetris environment for 150 000 steps.
 > python -m scripts.train
 """
 from pathlib import Path
-import sys; sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 import datetime as _dt
 


### PR DESCRIPTION
## Summary
- remove manual path mutation in `scripts/train.py`
- update quickstart docs to run `python -m scripts.train`
- note why training script must be executed as a module

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684588aa359c8321a3b4f41b349bf196