### PR TITLE
Update Stable-Baselines3 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gymnasium==0.29.1
-stable-baselines3==2.3.0
+stable-baselines3>=2.6.0
 pygame==2.6.1
 numpy==1.26.4
 pytest==8.2.1          # for `pytest -q`


### PR DESCRIPTION
## Summary
- bump Stable-Baselines3 requirement to `>=2.6.0`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*


------
https://chatgpt.com/codex/tasks/task_e_684588b48d8c8321b1a79dfa6743a766