### PR TITLE
Add CLI control over reward and PPO params

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 # requirements include stable-baselines3 extras and tensorboard for training logs
 pytest
 # train an agent
-python -m scripts.train
+python -m scripts.train --timesteps 200000 --line-reward 2.0
 # evaluate a saved model
 python -m scripts.eval --model path/to/model.zip
 # or use the management CLI
@@ -57,14 +57,19 @@ You can also call the subcommands directly:
 tetris-trainer setup
 
 # start a new training run
-tetris-trainer train --timesteps 200000
+tetris-trainer train --timesteps 200000 --line-reward 2.0
 
 # resume training from an existing model
-tetris-trainer resume --model logs/tb/20240101-120000/ppo_tetris.zip --timesteps 50000
+tetris-trainer resume --model logs/tb/20240101-120000/ppo_tetris.zip --timesteps 50000 --line-reward 2.0
 
 # launch TensorBoard to monitor progress
 tetris-trainer tensorboard
 ```
+
+Both the training script and CLI expose common PPO parameters such as
+`--learning-rate`, `--gamma` and a custom `--line-reward` that controls how
+valuable clearing a line is to the agent. Adjust these flags to experiment with
+different behaviours.
 
 When using the `-m` flag, give the module name with dots rather than a
 filesystem path. For instance run `python -m viewer.live_view`, not

--- a/env/tetris_env.py
+++ b/env/tetris_env.py
@@ -29,7 +29,7 @@ Action = int
 class TetrisEnv(gym.Env):
     metadata = {"render_modes": []}
 
-    def __init__(self, seed: int | None = None):
+    def __init__(self, seed: int | None = None, line_reward: float = 1.0):
         super().__init__()
         self.observation_space = spaces.Dict(
             {
@@ -45,6 +45,7 @@ class TetrisEnv(gym.Env):
         self.action_space = spaces.Discrete(6)
 
         self._rng = np.random.default_rng(seed)
+        self.line_reward = float(line_reward)
         self.board = np.zeros((BOARD_HEIGHT, BOARD_WIDTH), dtype=np.int8)
         self.current_id = 0
         self.piece = PIECES[0]
@@ -78,7 +79,7 @@ class TetrisEnv(gym.Env):
             self._lock_piece()
             lines = self._clear_lines()
             self._lines_total += lines
-            reward = float(lines)
+            reward = float(lines) * self.line_reward
             terminated = not self._spawn_new_piece()
         else:
             reward, terminated = 0.0, False

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -31,12 +31,14 @@ def setup_env(_: argparse.Namespace) -> None:
 
 def train(args: argparse.Namespace) -> None:
     """Train a new PPO agent."""
-    env = TetrisEnv()
+    env = TetrisEnv(line_reward=args.line_reward)
     ts = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
     log_dir = LOG_ROOT / ts
     model = PPO(
         policy="MultiInputPolicy",
         env=env,
+        learning_rate=args.learning_rate,
+        gamma=args.gamma,
         tensorboard_log=str(log_dir),
         verbose=1,
     )
@@ -48,8 +50,12 @@ def train(args: argparse.Namespace) -> None:
 
 def resume(args: argparse.Namespace) -> None:
     """Resume training from a saved model."""
-    env = TetrisEnv()
-    model = PPO.load(args.model, env=env)
+    env = TetrisEnv(line_reward=args.line_reward)
+    model = PPO.load(
+        args.model,
+        env=env,
+        custom_objects={"learning_rate": args.learning_rate, "gamma": args.gamma},
+    )
     model.learn(total_timesteps=args.timesteps, progress_bar=True, reset_num_timesteps=False)
     model.save(args.model)
     print(f"Resumed training – model saved to {args.model}")
@@ -92,13 +98,40 @@ def interactive_menu() -> None:
     cmd, (func, _) = options[idx]
     if cmd == "train":
         ts = input("Total timesteps [150000]: ").strip()
+        lr_in = input("Learning rate [0.0003]: ").strip()
+        g_in = input("Gamma [0.99]: ").strip()
+        lrw_in = input("Line reward [1.0]: ").strip()
         timesteps = int(ts) if ts else 150_000
-        func(argparse.Namespace(timesteps=timesteps))
+        lr = float(lr_in) if lr_in else 3e-4
+        gamma = float(g_in) if g_in else 0.99
+        line_reward = float(lrw_in) if lrw_in else 1.0
+        func(
+            argparse.Namespace(
+                timesteps=timesteps,
+                learning_rate=lr,
+                gamma=gamma,
+                line_reward=line_reward,
+            )
+        )
     elif cmd == "resume":
         model = input("Model path: ").strip()
         ts = input("Total timesteps [50000]: ").strip()
+        lr_in = input("Learning rate [0.0003]: ").strip()
+        g_in = input("Gamma [0.99]: ").strip()
+        lrw_in = input("Line reward [1.0]: ").strip()
         timesteps = int(ts) if ts else 50_000
-        func(argparse.Namespace(model=Path(model), timesteps=timesteps))
+        lr = float(lr_in) if lr_in else 3e-4
+        gamma = float(g_in) if g_in else 0.99
+        line_reward = float(lrw_in) if lrw_in else 1.0
+        func(
+            argparse.Namespace(
+                model=Path(model),
+                timesteps=timesteps,
+                learning_rate=lr,
+                gamma=gamma,
+                line_reward=line_reward,
+            )
+        )
     else:
         func(argparse.Namespace())
 
@@ -112,11 +145,17 @@ def main() -> None:
 
     train_parser = subparsers.add_parser("train", help="Start a new training run")
     train_parser.add_argument("--timesteps", type=int, default=150_000)
+    train_parser.add_argument("--learning-rate", type=float, default=3e-4)
+    train_parser.add_argument("--gamma", type=float, default=0.99)
+    train_parser.add_argument("--line-reward", type=float, default=1.0)
     train_parser.set_defaults(func=train)
 
     resume_parser = subparsers.add_parser("resume", help="Resume training from a model")
     resume_parser.add_argument("--model", type=Path, required=True)
     resume_parser.add_argument("--timesteps", type=int, default=50_000)
+    resume_parser.add_argument("--learning-rate", type=float, default=3e-4)
+    resume_parser.add_argument("--gamma", type=float, default=0.99)
+    resume_parser.add_argument("--line-reward", type=float, default=1.0)
     resume_parser.set_defaults(func=resume)
 
     tb_parser = subparsers.add_parser("tensorboard", help="Launch TensorBoard")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -5,6 +5,7 @@ Train PPO on the custom Tetris environment for 150 000 steps.
 """
 from pathlib import Path
 
+import argparse
 import datetime as _dt
 
 from stable_baselines3 import PPO
@@ -16,8 +17,15 @@ LOG_ROOT.mkdir(parents=True, exist_ok=True)
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Train PPO on Tetris")
+    parser.add_argument("--timesteps", type=int, default=150_000)
+    parser.add_argument("--learning-rate", type=float, default=3e-4)
+    parser.add_argument("--gamma", type=float, default=0.99)
+    parser.add_argument("--line-reward", type=float, default=1.0)
+    args = parser.parse_args()
+
     # 1️⃣ create env
-    env = TetrisEnv()
+    env = TetrisEnv(line_reward=args.line_reward)
 
     # 2️⃣ logging dir
     ts = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -27,12 +35,14 @@ def main() -> None:
     model = PPO(
         policy="MultiInputPolicy",
         env=env,
+        learning_rate=args.learning_rate,
+        gamma=args.gamma,
         tensorboard_log=str(log_dir),
         verbose=1,
     )
 
     # 4️⃣ learn
-    model.learn(total_timesteps=150_000, progress_bar=True)
+    model.learn(total_timesteps=args.timesteps, progress_bar=True)
 
     # 5️⃣ save
     model_path = log_dir / "ppo_tetris.zip"


### PR DESCRIPTION
## Summary
- expose `line_reward` in `TetrisEnv`
- allow adjusting PPO hyperparameters from `train.py`
- extend management CLI with options for learning rate, gamma and line reward
- document new flags in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684648ad589c8321bc5e2b98fa749cab