### PR TITLE
Add hole penalty and tetris bonus

### DIFF
--- a/env/tetris_env.py
+++ b/env/tetris_env.py
@@ -78,8 +78,12 @@ class TetrisEnv(gym.Env):
         if not moved:
             self._lock_piece()
             lines = self._clear_lines()
+            holes = self._count_holes()
             self._lines_total += lines
             reward = float(lines) * self.line_reward
+            if lines == 4:
+                reward *= 10
+            reward -= float(holes)
             terminated = not self._spawn_new_piece()
         else:
             reward, terminated = 0.0, False
@@ -139,3 +143,14 @@ class TetrisEnv(gym.Env):
                 [np.zeros((n, BOARD_WIDTH), dtype=np.int8), self.board[~full]]
             )
         return n
+
+    def _count_holes(self):
+        """Return the number of empty cells with at least one filled cell above."""
+        holes = 0
+        for c in range(BOARD_WIDTH):
+            column = self.board[:, c]
+            filled = np.flatnonzero(column)
+            if filled.size:
+                first = filled[0]
+                holes += int(np.sum(column[first:] == 0))
+        return holes

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -55,3 +55,16 @@ def test_game_over_when_spawn_blocked():
     env.board[0:4, 3:7] = 1
     _, _, terminated, _, _ = env.step(HARD_DROP)
     assert terminated
+
+
+def test_tetris_bonus():
+    env = TetrisEnv(seed=0)
+    env.reset()
+    env.board[-4:, 1:] = 1
+    env.piece = np.rot90(PIECES[0]).copy()
+    env.current_id = 0
+    env.pos = (0, 0)
+    obs, reward, terminated, truncated, info = env.step(HARD_DROP)
+    assert reward == 40.0
+    assert not terminated
+    assert info["lines_cleared"] == 4


### PR DESCRIPTION
## Summary
- discourage leaving holes by subtracting hole count from reward
- award 10x bonus when clearing four lines at once
- test tetris bonus in environment tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464bddf5a8832183d6e2ed1d977e1b