### PR TITLE
Increase Tetris line clearing rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install -r requirements.txt
 pytest
 # train an agent
 # train an agent
-python scripts/train.py --timesteps 200000 --line-reward 2.0
+python scripts/train.py --timesteps 200000 --line-reward 2.0 --tetris-bonus 20
 # evaluate a saved model
 python scripts/eval.py --model path/to/model.zip
 # or use the management script
@@ -55,19 +55,19 @@ Subcommands can be called directly:
 python scripts/manage.py setup
 
 # start a new training run
-python scripts/manage.py train --timesteps 200000 --line-reward 2.0
+python scripts/manage.py train --timesteps 200000 --line-reward 2.0 --tetris-bonus 20
 
 # resume training from an existing model
-python scripts/manage.py resume --model logs/tb/20240101-120000/ppo_tetris.zip --timesteps 50000 --line-reward 2.0
+python scripts/manage.py resume --model logs/tb/20240101-120000/ppo_tetris.zip --timesteps 50000 --line-reward 2.0 --tetris-bonus 20
 
 # launch TensorBoard to monitor progress
 python scripts/manage.py tensorboard
 ```
 
 Both the training script and management helper expose common PPO parameters
-such as `--learning-rate`, `--gamma` and a custom `--line-reward` that controls
-how valuable clearing a line is to the agent. Adjust these flags to experiment
-with different behaviours.
+such as `--learning-rate`, `--gamma`, `--line-reward` and the optional
+`--tetris-bonus` which controls how valuable clearing four lines at once is to
+the agent. Adjust these flags to experiment with different behaviours.
 
 ## License
 

--- a/env/tetris_env.py
+++ b/env/tetris_env.py
@@ -29,7 +29,12 @@ Action = int
 class TetrisEnv(gym.Env):
     metadata = {"render_modes": []}
 
-    def __init__(self, seed: int | None = None, line_reward: float = 1.0):
+    def __init__(
+        self,
+        seed: int | None = None,
+        line_reward: float = 1.0,
+        tetris_bonus: float = 20.0,
+    ):
         super().__init__()
         self.observation_space = spaces.Dict(
             {
@@ -46,6 +51,7 @@ class TetrisEnv(gym.Env):
 
         self._rng = np.random.default_rng(seed)
         self.line_reward = float(line_reward)
+        self.tetris_bonus = float(tetris_bonus)
         self.board = np.zeros((BOARD_HEIGHT, BOARD_WIDTH), dtype=np.int8)
         self.current_id = 0
         self.piece = PIECES[0]
@@ -82,7 +88,7 @@ class TetrisEnv(gym.Env):
             self._lines_total += lines
             reward = float(lines) * self.line_reward
             if lines == 4:
-                reward *= 10
+                reward *= self.tetris_bonus
             reward -= float(holes)
             terminated = not self._spawn_new_piece()
         else:

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -35,7 +35,10 @@ def setup_env(_: argparse.Namespace) -> None:
 
 def train(args: argparse.Namespace) -> None:
     """Train a new PPO agent."""
-    env = TetrisEnv(line_reward=args.line_reward)
+    env = TetrisEnv(
+        line_reward=args.line_reward,
+        tetris_bonus=args.tetris_bonus,
+    )
     ts = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
     log_dir = LOG_ROOT / ts
     model = PPO(
@@ -54,7 +57,10 @@ def train(args: argparse.Namespace) -> None:
 
 def resume(args: argparse.Namespace) -> None:
     """Resume training from a saved model."""
-    env = TetrisEnv(line_reward=args.line_reward)
+    env = TetrisEnv(
+        line_reward=args.line_reward,
+        tetris_bonus=args.tetris_bonus,
+    )
     model = PPO.load(
         args.model,
         env=env,
@@ -104,17 +110,20 @@ def interactive_menu() -> None:
         ts = input("Total timesteps [150000]: ").strip()
         lr_in = input("Learning rate [0.0003]: ").strip()
         g_in = input("Gamma [0.99]: ").strip()
-        lrw_in = input("Line reward [1.0]: ").strip()
+        lrw_in = input("Line reward [2.0]: ").strip()
+        tetris_in = input("Tetris bonus [20.0]: ").strip()
         timesteps = int(ts) if ts else 150_000
         lr = float(lr_in) if lr_in else 3e-4
         gamma = float(g_in) if g_in else 0.99
-        line_reward = float(lrw_in) if lrw_in else 1.0
+        line_reward = float(lrw_in) if lrw_in else 2.0
+        tetris_bonus = float(tetris_in) if tetris_in else 20.0
         func(
             argparse.Namespace(
                 timesteps=timesteps,
                 learning_rate=lr,
                 gamma=gamma,
                 line_reward=line_reward,
+                tetris_bonus=tetris_bonus,
             )
         )
     elif cmd == "resume":
@@ -122,11 +131,13 @@ def interactive_menu() -> None:
         ts = input("Total timesteps [50000]: ").strip()
         lr_in = input("Learning rate [0.0003]: ").strip()
         g_in = input("Gamma [0.99]: ").strip()
-        lrw_in = input("Line reward [1.0]: ").strip()
+        lrw_in = input("Line reward [2.0]: ").strip()
+        tetris_in = input("Tetris bonus [20.0]: ").strip()
         timesteps = int(ts) if ts else 50_000
         lr = float(lr_in) if lr_in else 3e-4
         gamma = float(g_in) if g_in else 0.99
-        line_reward = float(lrw_in) if lrw_in else 1.0
+        line_reward = float(lrw_in) if lrw_in else 2.0
+        tetris_bonus = float(tetris_in) if tetris_in else 20.0
         func(
             argparse.Namespace(
                 model=Path(model),
@@ -134,6 +145,7 @@ def interactive_menu() -> None:
                 learning_rate=lr,
                 gamma=gamma,
                 line_reward=line_reward,
+                tetris_bonus=tetris_bonus,
             )
         )
     else:
@@ -151,7 +163,8 @@ def main() -> None:
     train_parser.add_argument("--timesteps", type=int, default=150_000)
     train_parser.add_argument("--learning-rate", type=float, default=3e-4)
     train_parser.add_argument("--gamma", type=float, default=0.99)
-    train_parser.add_argument("--line-reward", type=float, default=1.0)
+    train_parser.add_argument("--line-reward", type=float, default=2.0)
+    train_parser.add_argument("--tetris-bonus", type=float, default=20.0)
     train_parser.set_defaults(func=train)
 
     resume_parser = subparsers.add_parser("resume", help="Resume training from a model")
@@ -159,7 +172,8 @@ def main() -> None:
     resume_parser.add_argument("--timesteps", type=int, default=50_000)
     resume_parser.add_argument("--learning-rate", type=float, default=3e-4)
     resume_parser.add_argument("--gamma", type=float, default=0.99)
-    resume_parser.add_argument("--line-reward", type=float, default=1.0)
+    resume_parser.add_argument("--line-reward", type=float, default=2.0)
+    resume_parser.add_argument("--tetris-bonus", type=float, default=20.0)
     resume_parser.set_defaults(func=resume)
 
     tb_parser = subparsers.add_parser("tensorboard", help="Launch TensorBoard")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -3,7 +3,7 @@ Train PPO on the custom Tetris environment for 150 000 steps.
 
 Example:
 
-    python scripts/train.py --timesteps 200000 --line-reward 2.0
+    python scripts/train.py --timesteps 200000 --line-reward 2.0 --tetris-bonus 20
 """
 from pathlib import Path
 import sys
@@ -28,11 +28,12 @@ def main() -> None:
     parser.add_argument("--timesteps", type=int, default=150_000)
     parser.add_argument("--learning-rate", type=float, default=3e-4)
     parser.add_argument("--gamma", type=float, default=0.99)
-    parser.add_argument("--line-reward", type=float, default=1.0)
+    parser.add_argument("--line-reward", type=float, default=2.0)
+    parser.add_argument("--tetris-bonus", type=float, default=20.0)
     args = parser.parse_args()
 
     # 1️⃣ create env
-    env = TetrisEnv(line_reward=args.line_reward)
+    env = TetrisEnv(line_reward=args.line_reward, tetris_bonus=args.tetris_bonus)
 
     # 2️⃣ logging dir
     ts = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -65,6 +65,6 @@ def test_tetris_bonus():
     env.current_id = 0
     env.pos = (0, 0)
     obs, reward, terminated, truncated, info = env.step(HARD_DROP)
-    assert reward == 40.0
+    assert reward == 80.0
     assert not terminated
     assert info["lines_cleared"] == 4


### PR DESCRIPTION
## Summary
- encourage tetrises by adding a `tetris_bonus` parameter to `TetrisEnv`
- default to higher rewards in training and management scripts
- document the new option in the README
- adjust tests for the new reward multiplier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846580b54f483219db2035339095eae